### PR TITLE
Typo in PaymentEmbedded.chargeback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+
+## 2.2.7
+- Fixed a typo in PaymentEmbedded.chargebacks
+
 ## 2.2.6
 - Made Config object part of the Client, instead of being a singleton.
   This allows multiple clients to have different configurations

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>be.feelio</groupId>
     <artifactId>mollie</artifactId>
-    <version>2.2.6</version>
+    <version>2.2.7</version>
 
     <name>Mollie with Java</name>
     <description>Java framework to consume the Mollie API</description>

--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,7 @@
     <properties>
         <jackson.version>2.10.1</jackson.version>
         <log4j.version>2.11.1</log4j.version>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <dependencies>

--- a/src/main/java/be/feelio/mollie/OAuthAwareObjectMapper.java
+++ b/src/main/java/be/feelio/mollie/OAuthAwareObjectMapper.java
@@ -13,7 +13,7 @@ public class OAuthAwareObjectMapper implements ObjectMapper {
 
     private final Config config;
 
-    public OAuthAwareObjectMapper(Config config) {
+    public OAuthAwareObjectMapper(Config config){
         this.config = config;
     }
 

--- a/src/main/java/be/feelio/mollie/OAuthAwareObjectMapper.java
+++ b/src/main/java/be/feelio/mollie/OAuthAwareObjectMapper.java
@@ -13,7 +13,7 @@ public class OAuthAwareObjectMapper implements ObjectMapper {
 
     private final Config config;
 
-    public OAuthAwareObjectMapper(Config config){
+    public OAuthAwareObjectMapper(Config config) {
         this.config = config;
     }
 

--- a/src/main/java/be/feelio/mollie/data/payment/PaymentEmbedded.java
+++ b/src/main/java/be/feelio/mollie/data/payment/PaymentEmbedded.java
@@ -17,5 +17,5 @@ public class PaymentEmbedded {
 
     private List<RefundResponse> refunds;
 
-    private List<ChargebackResponse> chagebacks;
+    private List<ChargebackResponse> chargebacks;
 }


### PR DESCRIPTION
This typo affected how the JSON is parsed and prevents reading chargebacks as part of a payment. I tested this locally against the mollie-api and it worked. 