### PR TITLE
Fix order expiresAt parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.2.2
+- Changed OrderRequest `expiresAt` field date serialization format to `yyyy-MM-dd`
+
 ## 3.2.0
 - Add support for category attribute in OrderLineRequest
 - Exposed the dashboard link in the OrderLink

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 3.2.2
+## 3.3.0
 - Changed OrderRequest `expiresAt` field date serialization format to `yyyy-MM-dd`
 
 ## 3.2.0

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -2,3 +2,4 @@
 - [Paul Van eijden](https://github.com/paulvaneijden)
 - [Carlos Freund](https://github.com/happyherp)
 - [Tom Martens](https://github.com/tomsnor)
+- [Dániel Szabó](https://github.com/szada92)

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>be.woutschoovaerts</groupId>
     <artifactId>mollie</artifactId>
-    <version>3.2.2</version>
+    <version>3.3.0</version>
 
     <name>Mollie with Java</name>
     <description>Java framework to consume the Mollie API</description>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>be.woutschoovaerts</groupId>
     <artifactId>mollie</artifactId>
-    <version>3.2.1</version>
+    <version>3.2.2</version>
 
     <name>Mollie with Java</name>
     <description>Java framework to consume the Mollie API</description>

--- a/src/main/java/be/woutschoovaerts/mollie/data/order/OrderRequest.java
+++ b/src/main/java/be/woutschoovaerts/mollie/data/order/OrderRequest.java
@@ -3,6 +3,7 @@ package be.woutschoovaerts.mollie.data.order;
 import be.woutschoovaerts.mollie.data.common.Amount;
 import be.woutschoovaerts.mollie.data.common.Locale;
 import be.woutschoovaerts.mollie.data.payment.PaymentMethod;
+import be.woutschoovaerts.mollie.serializer.ISO8601DateFormatSerializer;
 import be.woutschoovaerts.mollie.serializer.PaymentMethodSerializer;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import lombok.AllArgsConstructor;
@@ -51,6 +52,7 @@ public class OrderRequest {
 
     private Map<String, Object> metadata;
 
+    @JsonSerialize(using = ISO8601DateFormatSerializer.class)
     private Optional<Date> expiresAt = Optional.empty();
 
     // OAuth Params

--- a/src/main/java/be/woutschoovaerts/mollie/serializer/ISO8601DateFormatSerializer.java
+++ b/src/main/java/be/woutschoovaerts/mollie/serializer/ISO8601DateFormatSerializer.java
@@ -1,0 +1,31 @@
+package be.woutschoovaerts.mollie.serializer;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+
+import java.io.IOException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Objects;
+import java.util.Optional;
+
+public class ISO8601DateFormatSerializer extends JsonSerializer<Optional<Date>> {
+
+    private static final SimpleDateFormat ISO_8601_DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd");
+
+    @Override
+    public void serialize(Optional<Date> optionalDate, JsonGenerator jsonGenerator,
+                          SerializerProvider serializerProvider)
+            throws IOException {
+        Objects.requireNonNull(optionalDate, "'optionalDate' parameter to serialize cannot be null!");
+
+        if (!optionalDate.isPresent()) {
+            jsonGenerator.writeNull();
+            return;
+        }
+
+        Date date = optionalDate.get();
+        jsonGenerator.writeString(ISO_8601_DATE_FORMAT.format(date));
+    }
+}

--- a/src/test/java/be/woutschoovaerts/mollie/serializer/ISO8601DateFormatSerializerTest.java
+++ b/src/test/java/be/woutschoovaerts/mollie/serializer/ISO8601DateFormatSerializerTest.java
@@ -1,0 +1,83 @@
+package be.woutschoovaerts.mollie.serializer;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+
+import java.io.IOException;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+
+class ISO8601DateFormatSerializerTest {
+
+    private ISO8601DateFormatSerializer dateFormatSerializer;
+    private JsonGenerator jsonGenerator;
+    private SerializerProvider serializerProvider;
+    private ArgumentCaptor<String> argumentCaptor;
+
+    @BeforeEach
+    void before() {
+        this.dateFormatSerializer = new ISO8601DateFormatSerializer();
+        this.jsonGenerator = Mockito.mock(JsonGenerator.class);
+        this.serializerProvider = Mockito.mock(SerializerProvider.class);
+        this.argumentCaptor = ArgumentCaptor.forClass(String.class);
+    }
+
+    /**
+     * Note: this should not occur according to
+     * {@link com.fasterxml.jackson.databind.JsonSerializer#serialize(Object, JsonGenerator, SerializerProvider)}
+     * documentation.
+     */
+    @Test
+    void serializeNull() {
+        Assertions.assertThrows(NullPointerException.class, () -> {
+            this.dateFormatSerializer.serialize(null, jsonGenerator, serializerProvider);
+        });
+    }
+
+    @Test
+    void serializeEmptyOptional() throws IOException {
+        // when
+        this.dateFormatSerializer.serialize(Optional.empty(), jsonGenerator, serializerProvider);
+
+        // then
+        Mockito.verify(jsonGenerator).writeNull();
+    }
+
+    @Test
+    void serializeDate() throws IOException {
+        // given
+        Calendar calendar = Calendar.getInstance();
+        calendar.set(2022, Calendar.JANUARY, 1, 12, 0);
+        Date date = calendar.getTime();
+
+        // when
+        this.dateFormatSerializer.serialize(Optional.of(date), jsonGenerator, serializerProvider);
+
+        // then
+        Mockito.verify(jsonGenerator).writeString(argumentCaptor.capture());
+        Assertions.assertEquals("2022-01-01", argumentCaptor.getValue());
+    }
+
+    @Test
+    void serializeMinimumDate() throws IOException {
+        // given
+        Calendar calendar = Calendar.getInstance();
+        calendar.set(0, Calendar.JANUARY, 1, 0, 0);
+        Date date = calendar.getTime();
+
+        // when
+        this.dateFormatSerializer.serialize(Optional.of(date), jsonGenerator, serializerProvider);
+
+        // then
+        Mockito.verify(jsonGenerator).writeString(argumentCaptor.capture());
+        Assertions.assertEquals("0001-01-01", argumentCaptor.getValue());
+    }
+
+}


### PR DESCRIPTION
Based on Mollie API (https://docs.mollie.com/reference/v2/orders-api/create-order):

expiresAt : string (OPTIONAL): The date the order should expire in YYYY-MM-DD format. The minimum date is tomorrow and the maximum date is 100 days after tomorrow.

I have changed the expiresAt parameter from java.util.Date to java.time.LocalDate and registered the required JavaTimeModule mapper to Jackson.