### PR TITLE
Allow a custom user agent header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 3.3.0
-- Allow a custom user agent header
+- Allow a custom user agent string
 
 ## 3.2.0
 - Exposed the dashboard link in the OrderLink

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.3.0
+- Allow a custom user agent header
+
 ## 3.2.0
 - Exposed the dashboard link in the OrderLink
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -2,3 +2,4 @@
 - [Paul Van eijden](https://github.com/paulvaneijden)
 - [Carlos Freund](https://github.com/happyherp)
 - [Tom Martens](https://github.com/tomsnor)
+- [Tim Smelik](https://github.com/timsmelik)

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This library requires Java 8+.
 <dependency>
     <groupId>be.woutschoovaerts</groupId>
     <artifactId>mollie</artifactId>
-    <version>3.2.0</version>
+    <version>3.3.0</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>be.woutschoovaerts</groupId>
     <artifactId>mollie</artifactId>
-    <version>3.2.0</version>
+    <version>3.3.0</version>
 
     <name>Mollie with Java</name>
     <description>Java framework to consume the Mollie API</description>

--- a/src/main/java/be/woutschoovaerts/mollie/Client.java
+++ b/src/main/java/be/woutschoovaerts/mollie/Client.java
@@ -60,8 +60,8 @@ public class Client {
     /**
      * Set the user agent string
      */
-    public void setUserAgent(String userAgent) {
-        config.setUserAgent(userAgent);
+    public void setUserAgentString(String userAgentString) {
+        config.setUserAgentString(userAgentString);
     }
 
     /**

--- a/src/main/java/be/woutschoovaerts/mollie/Client.java
+++ b/src/main/java/be/woutschoovaerts/mollie/Client.java
@@ -58,6 +58,13 @@ public class Client {
     }
 
     /**
+     * Set the user agent string
+     */
+    public void setUserAgent(String userAgent) {
+        config.setUserAgent(userAgent);
+    }
+
+    /**
      * Handles connect actions
      *
      * @return ConnectHandler object

--- a/src/main/java/be/woutschoovaerts/mollie/ClientBuilder.java
+++ b/src/main/java/be/woutschoovaerts/mollie/ClientBuilder.java
@@ -5,6 +5,7 @@ public final class ClientBuilder {
     private String apiKey;
     private String organizationToken;
     private boolean testMode = false;
+    private String userAgent;
 
     public ClientBuilder withApiKey(String key) {
         this.apiKey = key;
@@ -21,6 +22,11 @@ public final class ClientBuilder {
         return this;
     }
 
+    public ClientBuilder withUserAgent(String customUserAgent) {
+        this.userAgent = customUserAgent;
+        return this;
+    }
+
     public Client build() {
         if (apiKey == null) {
             throw new IllegalArgumentException("API key not set. Please use withApiKey(key)");
@@ -34,6 +40,10 @@ public final class ClientBuilder {
 
         if (testMode) {
             client.enableTestMode();
+        }
+
+        if (userAgent != null) {
+            client.setUserAgent(userAgent);
         }
 
         return client;

--- a/src/main/java/be/woutschoovaerts/mollie/ClientBuilder.java
+++ b/src/main/java/be/woutschoovaerts/mollie/ClientBuilder.java
@@ -5,7 +5,7 @@ public final class ClientBuilder {
     private String apiKey;
     private String organizationToken;
     private boolean testMode = false;
-    private String userAgent;
+    private String userAgentString;
 
     public ClientBuilder withApiKey(String key) {
         this.apiKey = key;
@@ -22,8 +22,8 @@ public final class ClientBuilder {
         return this;
     }
 
-    public ClientBuilder withUserAgent(String customUserAgent) {
-        this.userAgent = customUserAgent;
+    public ClientBuilder withUserAgent(String customUserAgentString) {
+        this.userAgentString = customUserAgentString;
         return this;
     }
 
@@ -42,8 +42,8 @@ public final class ClientBuilder {
             client.enableTestMode();
         }
 
-        if (userAgent != null) {
-            client.setUserAgent(userAgent);
+        if (userAgentString != null) {
+            client.setUserAgentString(userAgentString);
         }
 
         return client;

--- a/src/main/java/be/woutschoovaerts/mollie/handler/AbstractHandler.java
+++ b/src/main/java/be/woutschoovaerts/mollie/handler/AbstractHandler.java
@@ -43,8 +43,7 @@ public abstract class AbstractHandler {
 
         HttpResponse<String> response = Unirest
                 .get(url)
-                .header("Content-Type", "application/json")
-                .header("Authorization", "Bearer " + config.getBearerToken())
+                .headers(getHeaderMap())
                 .asString();
 
         validateResponse(response);
@@ -61,8 +60,7 @@ public abstract class AbstractHandler {
 
         HttpResponse<String> response = Unirest
                 .post(url)
-                .header("Content-Type", "application/json")
-                .header("Authorization", "Bearer " + config.getBearerToken())
+                .headers(getHeaderMap())
                 .asString();
 
         validateResponse(response);
@@ -83,8 +81,7 @@ public abstract class AbstractHandler {
 
         HttpResponse<String> response = Unirest
                 .post(url)
-                .header("Content-Type", "application/json")
-                .header("Authorization", "Bearer " + config.getBearerToken())
+                .headers(getHeaderMap())
                 .body(body)
                 .asString();
 
@@ -106,8 +103,7 @@ public abstract class AbstractHandler {
 
         HttpResponse<String> response = Unirest
                 .patch(url)
-                .header("Content-Type", "application/json")
-                .header("Authorization", "Bearer " + config.getBearerToken())
+                .headers(getHeaderMap())
                 .body(body)
                 .asString();
 
@@ -133,8 +129,7 @@ public abstract class AbstractHandler {
 
         HttpResponse<String> response = Unirest
                 .delete(url)
-                .header("Content-Type", "application/json")
-                .header("Authorization", "Bearer " + config.getBearerToken())
+                .headers(getHeaderMap())
                 .body(body)
                 .asString();
 
@@ -152,8 +147,7 @@ public abstract class AbstractHandler {
 
         HttpResponse<String> response = Unirest
                 .delete(url)
-                .header("Content-Type", "application/json")
-                .header("Authorization", "Bearer " + config.getBearerToken())
+                .headers(getHeaderMap())
                 .body(body)
                 .asString();
 
@@ -171,5 +165,16 @@ public abstract class AbstractHandler {
                     new TypeReference<Map>() {
                     }));
         }
+    }
+
+    private Map<String, String> getHeaderMap() {
+        Map<String, String> map = new HashMap<>();
+
+        map.put("Content-Type", "application/json");
+        map.put("Authorization", "Bearer " + config.getBearerToken());
+
+        config.getUserAgent().ifPresent(userAgent -> map.put("User-Agent", userAgent));
+
+        return map;
     }
 }

--- a/src/main/java/be/woutschoovaerts/mollie/handler/AbstractHandler.java
+++ b/src/main/java/be/woutschoovaerts/mollie/handler/AbstractHandler.java
@@ -173,7 +173,7 @@ public abstract class AbstractHandler {
         map.put("Content-Type", "application/json");
         map.put("Authorization", "Bearer " + config.getBearerToken());
 
-        config.getUserAgent().ifPresent(userAgent -> map.put("User-Agent", userAgent));
+        config.getUserAgentString().ifPresent(userAgentString -> map.put("User-Agent", userAgentString));
 
         return map;
     }

--- a/src/main/java/be/woutschoovaerts/mollie/handler/AbstractHandler.java
+++ b/src/main/java/be/woutschoovaerts/mollie/handler/AbstractHandler.java
@@ -43,7 +43,7 @@ public abstract class AbstractHandler {
 
         HttpResponse<String> response = Unirest
                 .get(url)
-                .headers(getHeaderMap())
+                .headers(configureAllHeaders())
                 .asString();
 
         validateResponse(response);
@@ -60,7 +60,7 @@ public abstract class AbstractHandler {
 
         HttpResponse<String> response = Unirest
                 .post(url)
-                .headers(getHeaderMap())
+                .headers(configureAllHeaders())
                 .asString();
 
         validateResponse(response);
@@ -81,7 +81,7 @@ public abstract class AbstractHandler {
 
         HttpResponse<String> response = Unirest
                 .post(url)
-                .headers(getHeaderMap())
+                .headers(configureAllHeaders())
                 .body(body)
                 .asString();
 
@@ -103,7 +103,7 @@ public abstract class AbstractHandler {
 
         HttpResponse<String> response = Unirest
                 .patch(url)
-                .headers(getHeaderMap())
+                .headers(configureAllHeaders())
                 .body(body)
                 .asString();
 
@@ -129,7 +129,7 @@ public abstract class AbstractHandler {
 
         HttpResponse<String> response = Unirest
                 .delete(url)
-                .headers(getHeaderMap())
+                .headers(configureAllHeaders())
                 .body(body)
                 .asString();
 
@@ -147,7 +147,7 @@ public abstract class AbstractHandler {
 
         HttpResponse<String> response = Unirest
                 .delete(url)
-                .headers(getHeaderMap())
+                .headers(configureAllHeaders())
                 .body(body)
                 .asString();
 
@@ -167,7 +167,7 @@ public abstract class AbstractHandler {
         }
     }
 
-    private Map<String, String> getHeaderMap() {
+    private Map<String, String> configureAllHeaders() {
         Map<String, String> map = new HashMap<>();
 
         map.put("Content-Type", "application/json");

--- a/src/main/java/be/woutschoovaerts/mollie/util/Config.java
+++ b/src/main/java/be/woutschoovaerts/mollie/util/Config.java
@@ -4,6 +4,8 @@ import lombok.Getter;
 import lombok.Setter;
 import org.apache.commons.lang3.StringUtils;
 
+import java.util.Optional;
+
 public final class Config {
 
     @Getter
@@ -18,11 +20,18 @@ public final class Config {
     @Setter
     private boolean testMode;
 
+    @Setter
+    private String userAgent;
+
     public String getBearerToken() {
         return StringUtils.isBlank(accessToken) ? apiKey : accessToken;
     }
 
     public boolean shouldAddTestMode() {
         return !StringUtils.isBlank(accessToken) && testMode;
+    }
+
+    public Optional<String> getUserAgent() {
+        return Optional.ofNullable(userAgent);
     }
 }

--- a/src/main/java/be/woutschoovaerts/mollie/util/Config.java
+++ b/src/main/java/be/woutschoovaerts/mollie/util/Config.java
@@ -21,7 +21,7 @@ public final class Config {
     private boolean testMode;
 
     @Setter
-    private String userAgent;
+    private String userAgentString;
 
     public String getBearerToken() {
         return StringUtils.isBlank(accessToken) ? apiKey : accessToken;
@@ -31,7 +31,7 @@ public final class Config {
         return !StringUtils.isBlank(accessToken) && testMode;
     }
 
-    public Optional<String> getUserAgent() {
-        return Optional.ofNullable(userAgent);
+    public Optional<String> getUserAgentString() {
+        return Optional.ofNullable(userAgentString);
     }
 }

--- a/src/test/java/be/woutschoovaerts/mollie/ClientBuilderTest.java
+++ b/src/test/java/be/woutschoovaerts/mollie/ClientBuilderTest.java
@@ -1,5 +1,7 @@
 package be.woutschoovaerts.mollie;
 
+import java.util.Optional;
+
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -39,5 +41,16 @@ class ClientBuilderTest {
 
         assertNotNull(client);
         assertTrue(client.getConfig().isTestMode());
+    }
+
+    @Test
+    void build_withUserAgent() {
+        Client client = new ClientBuilder()
+                .withApiKey("my-api-key")
+                .withUserAgent("my-user-agent")
+                .build();
+
+        assertNotNull(client);
+        assertEquals(Optional.of("my-user-agent"), client.getConfig().getUserAgent());
     }
 }

--- a/src/test/java/be/woutschoovaerts/mollie/ClientBuilderTest.java
+++ b/src/test/java/be/woutschoovaerts/mollie/ClientBuilderTest.java
@@ -5,7 +5,6 @@ import java.util.Optional;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
-
 class ClientBuilderTest {
 
     @Test
@@ -44,13 +43,13 @@ class ClientBuilderTest {
     }
 
     @Test
-    void build_withUserAgent() {
+    void build_withUserAgentString() {
         Client client = new ClientBuilder()
                 .withApiKey("my-api-key")
-                .withUserAgent("my-user-agent")
+                .withUserAgent("my-user-agent-string")
                 .build();
 
         assertNotNull(client);
-        assertEquals(Optional.of("my-user-agent"), client.getConfig().getUserAgent());
+        assertEquals(Optional.of("my-user-agent-string"), client.getConfig().getUserAgentString());
     }
 }

--- a/src/test/java/be/woutschoovaerts/mollie/ClientTest.java
+++ b/src/test/java/be/woutschoovaerts/mollie/ClientTest.java
@@ -1,5 +1,7 @@
 package be.woutschoovaerts.mollie;
 
+import java.util.Optional;
+
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -52,7 +54,22 @@ class ClientTest {
 
         assertFalse(client.getConfig().isTestMode());
     }
-    
+
+    @Test
+    void setUserAgent() {
+        Client client = new Client("apiKey");
+        client.setUserAgent("user_agent/version");
+
+        assertEquals(Optional.of("user_agent/version"), client.getConfig().getUserAgent());
+    }
+
+    @Test
+    void defaultUserAgent() {
+        Client client = new Client("apiKey");
+
+        assertEquals(Optional.empty(), client.getConfig().getUserAgent());
+    }
+
     @Test
     void twoClients(){
         Client client1 = new Client("apiKey1");

--- a/src/test/java/be/woutschoovaerts/mollie/ClientTest.java
+++ b/src/test/java/be/woutschoovaerts/mollie/ClientTest.java
@@ -56,18 +56,18 @@ class ClientTest {
     }
 
     @Test
-    void setUserAgent() {
+    void setUserAgentString() {
         Client client = new Client("apiKey");
-        client.setUserAgent("user_agent/version");
+        client.setUserAgentString("user_agent/version");
 
-        assertEquals(Optional.of("user_agent/version"), client.getConfig().getUserAgent());
+        assertEquals(Optional.of("user_agent/version"), client.getConfig().getUserAgentString());
     }
 
     @Test
-    void defaultUserAgent() {
+    void defaultUserAgentString() {
         Client client = new Client("apiKey");
 
-        assertEquals(Optional.empty(), client.getConfig().getUserAgent());
+        assertEquals(Optional.empty(), client.getConfig().getUserAgentString());
     }
 
     @Test


### PR DESCRIPTION
Mollie recommends [setting the user agent header](https://docs.mollie.com/integration-partners/user-agent-strings) in calls in order to link calls to products or organizations.

I removed some duplicate code in AbstractHandler, if you did that on purpose to prevent creating additional maps let me know and I'll revert that change.