### PR TITLE
Voucher payment method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 3.2.2
+## 3.2.3
 - Add "voucher" as a known payment method
 
 ## 3.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.2.2
+- Add "voucher" as a known payment method
+
 ## 3.2.0
 - Add support for category attribute in OrderLineRequest
 - Exposed the dashboard link in the OrderLink

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>be.woutschoovaerts</groupId>
     <artifactId>mollie</artifactId>
-    <version>3.2.1</version>
+    <version>3.2.2</version>
 
     <name>Mollie with Java</name>
     <description>Java framework to consume the Mollie API</description>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>be.woutschoovaerts</groupId>
     <artifactId>mollie</artifactId>
-    <version>3.2.2</version>
+    <version>3.2.3</version>
 
     <name>Mollie with Java</name>
     <description>Java framework to consume the Mollie API</description>

--- a/src/main/java/be/woutschoovaerts/mollie/data/payment/PaymentMethod.java
+++ b/src/main/java/be/woutschoovaerts/mollie/data/payment/PaymentMethod.java
@@ -24,7 +24,8 @@ public enum PaymentMethod {
     PAYPAL("paypal"),
     PAY_SAFE_CARD("paysafecard"),
     PRZELEWY24("przelewy24"),
-    SOFORT("sofort");
+    SOFORT("sofort"),
+    VOUCHER("voucher");
 
     private final String value;
 


### PR DESCRIPTION
Add "voucher" as a known payment method

This method is not mentioned in the Mollie docs at https://docs.mollie.com/reference/v2/payments-api/get-payment but is returned in the OrderResponse when a payment is made using (eco) voucher