### PR TITLE
Usage of java.time package instead of java.util.Date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.4.0
+- Changed `java.util.Date` fields to its `java.time` representatives
+
 ## 3.3.0
 - Changed OrderRequest `expiresAt` field date serialization format to `yyyy-MM-dd`
 

--- a/pom.xml
+++ b/pom.xml
@@ -78,6 +78,12 @@
         </dependency>
 
         <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jsr310</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
             <version>3.8</version>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>be.woutschoovaerts</groupId>
     <artifactId>mollie</artifactId>
-    <version>3.3.0</version>
+    <version>3.4.0</version>
 
     <name>Mollie with Java</name>
     <description>Java framework to consume the Mollie API</description>

--- a/src/main/java/be/woutschoovaerts/mollie/data/capture/CaptureResponse.java
+++ b/src/main/java/be/woutschoovaerts/mollie/data/capture/CaptureResponse.java
@@ -8,7 +8,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-import java.util.Date;
+import java.time.OffsetDateTime;
 import java.util.Optional;
 
 @Data
@@ -33,7 +33,7 @@ public class CaptureResponse {
 
     private Optional<String> settlementId  = Optional.empty();
 
-    private Date createdAt;
+    private OffsetDateTime createdAt;
 
     @JsonProperty("_links")
     private CaptureLinks links;

--- a/src/main/java/be/woutschoovaerts/mollie/data/chargeback/ChargebackResponse.java
+++ b/src/main/java/be/woutschoovaerts/mollie/data/chargeback/ChargebackResponse.java
@@ -8,7 +8,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-import java.util.Date;
+import java.time.OffsetDateTime;
 import java.util.Optional;
 
 @Data
@@ -25,9 +25,9 @@ public class ChargebackResponse {
 
     private Amount settlementAmount;
 
-    private Date createdAt;
+    private OffsetDateTime createdAt;
 
-    private Date reversedAt;
+    private OffsetDateTime reversedAt;
 
     private String paymentId;
 

--- a/src/main/java/be/woutschoovaerts/mollie/data/customer/CustomerResponse.java
+++ b/src/main/java/be/woutschoovaerts/mollie/data/customer/CustomerResponse.java
@@ -7,7 +7,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-import java.util.Date;
+import java.time.OffsetDateTime;
 import java.util.Locale;
 import java.util.Map;
 
@@ -31,7 +31,7 @@ public class CustomerResponse {
 
     private Map<String, Object> metadata;
 
-    private Date createdAt;
+    private OffsetDateTime createdAt;
 
     @JsonProperty("_links")
     private CustomerLinks links;

--- a/src/main/java/be/woutschoovaerts/mollie/data/invoice/InvoiceResponse.java
+++ b/src/main/java/be/woutschoovaerts/mollie/data/invoice/InvoiceResponse.java
@@ -7,7 +7,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-import java.util.Date;
+import java.time.LocalDate;
 import java.util.List;
 
 @Data
@@ -26,11 +26,11 @@ public class InvoiceResponse {
 
     private InvoiceStatus status;
 
-    private Date issuedAt;
+    private LocalDate issuedAt;
 
-    private Date paidAt;
+    private LocalDate paidAt;
 
-    private Date dueAt;
+    private LocalDate dueAt;
 
     private Amount netAmount;
 

--- a/src/main/java/be/woutschoovaerts/mollie/data/mandate/MandateDetailsResponse.java
+++ b/src/main/java/be/woutschoovaerts/mollie/data/mandate/MandateDetailsResponse.java
@@ -5,7 +5,8 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-import java.util.Date;
+
+import java.time.LocalDate;
 import java.util.Optional;
 
 @Data
@@ -28,6 +29,6 @@ public class MandateDetailsResponse {
 
     private Optional<String> cardFingerprint = Optional.empty();
 
-    private Optional<Date> cardExpiryDate = Optional.empty();
+    private Optional<LocalDate> cardExpiryDate = Optional.empty();
 
 }

--- a/src/main/java/be/woutschoovaerts/mollie/data/mandate/MandateRequest.java
+++ b/src/main/java/be/woutschoovaerts/mollie/data/mandate/MandateRequest.java
@@ -6,7 +6,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-import java.util.Date;
+import java.time.LocalDate;
 import java.util.Optional;
 
 @Data
@@ -24,7 +24,7 @@ public class MandateRequest {
     private Optional<String> consumerBic = Optional.empty();
 
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
-    private Optional<Date> signatureDate = Optional.empty();
+    private Optional<LocalDate> signatureDate = Optional.empty();
 
     private Optional<String> mandateReference = Optional.empty();
 }

--- a/src/main/java/be/woutschoovaerts/mollie/data/mandate/MandateResponse.java
+++ b/src/main/java/be/woutschoovaerts/mollie/data/mandate/MandateResponse.java
@@ -7,7 +7,9 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-import java.util.Date;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+
 
 @Data
 @AllArgsConstructor
@@ -27,9 +29,9 @@ public class MandateResponse {
 
     private String mandateReference;
 
-    private Date signatureDate;
+    private LocalDate signatureDate;
 
-    private Date createdAt;
+    private OffsetDateTime createdAt;
 
     @JsonProperty("_links")
     private MandateLinks links;

--- a/src/main/java/be/woutschoovaerts/mollie/data/onboarding/OnboardingResponse.java
+++ b/src/main/java/be/woutschoovaerts/mollie/data/onboarding/OnboardingResponse.java
@@ -6,7 +6,8 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-import java.util.Date;
+import java.time.OffsetDateTime;
+
 
 @Data
 @AllArgsConstructor
@@ -18,7 +19,7 @@ public class OnboardingResponse {
 
     private String name;
 
-    private Date signedUpAt;
+    private OffsetDateTime signedUpAt;
 
     private OnboardingStatus status;
 

--- a/src/main/java/be/woutschoovaerts/mollie/data/order/OrderLineResponse.java
+++ b/src/main/java/be/woutschoovaerts/mollie/data/order/OrderLineResponse.java
@@ -7,7 +7,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-import java.util.Date;
+import java.time.OffsetDateTime;
 import java.util.Optional;
 
 @Data
@@ -62,7 +62,7 @@ public class OrderLineResponse {
     @Builder.Default
     private Optional<String> sku = Optional.empty();
 
-    private Date createdAt;
+    private OffsetDateTime createdAt;
 
     @JsonProperty("_links")
     private OrderLineLinks links;

--- a/src/main/java/be/woutschoovaerts/mollie/data/order/OrderRequest.java
+++ b/src/main/java/be/woutschoovaerts/mollie/data/order/OrderRequest.java
@@ -3,7 +3,6 @@ package be.woutschoovaerts.mollie.data.order;
 import be.woutschoovaerts.mollie.data.common.Amount;
 import be.woutschoovaerts.mollie.data.common.Locale;
 import be.woutschoovaerts.mollie.data.payment.PaymentMethod;
-import be.woutschoovaerts.mollie.serializer.ISO8601DateFormatSerializer;
 import be.woutschoovaerts.mollie.serializer.PaymentMethodSerializer;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import lombok.AllArgsConstructor;
@@ -11,7 +10,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-import java.util.Date;
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -34,7 +33,7 @@ public class OrderRequest {
     private Optional<OrderAddressRequest> shippingAddress = Optional.empty();
 
     @Builder.Default
-    private Optional<Date> consumerDateOfBirth = Optional.empty();
+    private Optional<LocalDate> consumerDateOfBirth = Optional.empty();
 
     @Builder.Default
     private Optional<String> redirectUrl = Optional.empty();
@@ -52,8 +51,7 @@ public class OrderRequest {
 
     private Map<String, Object> metadata;
 
-    @JsonSerialize(using = ISO8601DateFormatSerializer.class)
-    private Optional<Date> expiresAt = Optional.empty();
+    private Optional<LocalDate> expiresAt = Optional.empty();
 
     // OAuth Params
     @Builder.Default

--- a/src/main/java/be/woutschoovaerts/mollie/data/order/OrderResponse.java
+++ b/src/main/java/be/woutschoovaerts/mollie/data/order/OrderResponse.java
@@ -8,7 +8,13 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-import java.util.*;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 
 @Data
 @AllArgsConstructor
@@ -41,7 +47,7 @@ public class  OrderResponse {
     private OrderAddressResponse billingAddress;
 
     @Builder.Default
-    private Optional<Date> consumerDateOfBirth = Optional.empty();
+    private Optional<LocalDate> consumerDateOfBirth = Optional.empty();
 
     private String orderNumber;
 
@@ -60,25 +66,25 @@ public class  OrderResponse {
     @Builder.Default
     private Optional<String> webhookUrl = Optional.empty();
 
-    private Date createdAt;
+    private OffsetDateTime createdAt;
 
     @Builder.Default
-    private Optional<Date> expiresAt = Optional.empty();
+    private Optional<OffsetDateTime> expiresAt = Optional.empty();
 
     @Builder.Default
-    private Optional<Date> expiredAt  = Optional.empty();
+    private Optional<OffsetDateTime> expiredAt  = Optional.empty();
 
     @Builder.Default
-    private Optional<Date> paidAt  = Optional.empty();
+    private Optional<OffsetDateTime> paidAt  = Optional.empty();
 
     @Builder.Default
-    private Optional<Date> authorizedAt  = Optional.empty();
+    private Optional<OffsetDateTime> authorizedAt  = Optional.empty();
 
     @Builder.Default
-    private Optional<Date> canceledAt  = Optional.empty();
+    private Optional<OffsetDateTime> canceledAt  = Optional.empty();
 
     @Builder.Default
-    private Optional<Date> completedAt  = Optional.empty();
+    private Optional<OffsetDateTime> completedAt  = Optional.empty();
 
     @Builder.Default
     @JsonProperty("_embedded")

--- a/src/main/java/be/woutschoovaerts/mollie/data/payment/PaymentDetailsResponse.java
+++ b/src/main/java/be/woutschoovaerts/mollie/data/payment/PaymentDetailsResponse.java
@@ -6,7 +6,8 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-import java.util.Date;
+
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 
@@ -74,9 +75,9 @@ public class PaymentDetailsResponse {
 
     private Optional<String> creditorIdentifier = Optional.empty();
 
-    private Optional<Date> dueDate = Optional.empty();
+    private Optional<LocalDate> dueDate = Optional.empty();
 
-    private Optional<Date> signatureDate = Optional.empty();
+    private Optional<LocalDate> signatureDate = Optional.empty();
 
     private Optional<String> bankReasonCode = Optional.empty();
 

--- a/src/main/java/be/woutschoovaerts/mollie/data/payment/PaymentRequest.java
+++ b/src/main/java/be/woutschoovaerts/mollie/data/payment/PaymentRequest.java
@@ -9,7 +9,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-import java.util.Date;
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -46,7 +46,7 @@ public class PaymentRequest {
 
     private Optional<String> billingEmail = Optional.empty();
 
-    private Optional<Date> dueDate = Optional.empty();
+    private Optional<LocalDate> dueDate = Optional.empty();
 
     private Optional<AddressRequest> billingAddress = Optional.empty();
 

--- a/src/main/java/be/woutschoovaerts/mollie/data/payment/PaymentResponse.java
+++ b/src/main/java/be/woutschoovaerts/mollie/data/payment/PaymentResponse.java
@@ -9,7 +9,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-import java.util.Date;
+import java.time.OffsetDateTime;
 import java.util.Map;
 import java.util.Optional;
 
@@ -25,23 +25,23 @@ public class PaymentResponse {
 
     private String mode;
 
-    private Date createdAt;
+    private OffsetDateTime createdAt;
 
     private PaymentStatus status;
 
     private boolean isCancelable;
 
-    private Optional<Date> authorizedAt = Optional.empty();
+    private Optional<OffsetDateTime> authorizedAt = Optional.empty();
 
-    private Optional<Date> paidAt = Optional.empty();
+    private Optional<OffsetDateTime> paidAt = Optional.empty();
 
-    private Optional<Date> canceledAt = Optional.empty();
+    private Optional<OffsetDateTime> canceledAt = Optional.empty();
 
-    private Date expiresAt;
+    private OffsetDateTime expiresAt;
 
-    private Optional<Date> expiredAt = Optional.empty();
+    private Optional<OffsetDateTime> expiredAt = Optional.empty();
 
-    private Optional<Date> failedAt = Optional.empty();
+    private Optional<OffsetDateTime> failedAt = Optional.empty();
 
     private Amount amount;
 

--- a/src/main/java/be/woutschoovaerts/mollie/data/profile/ProfileResponse.java
+++ b/src/main/java/be/woutschoovaerts/mollie/data/profile/ProfileResponse.java
@@ -6,7 +6,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-import java.util.Date;
+import java.time.OffsetDateTime;
 
 @Data
 @AllArgsConstructor
@@ -34,7 +34,7 @@ public class ProfileResponse {
 
     private ProfileReviewResponse review;
 
-    private Date createdAt;
+    private OffsetDateTime createdAt;
 
     @JsonProperty("_links")
     private ProfileLinks links;

--- a/src/main/java/be/woutschoovaerts/mollie/data/refund/RefundResponse.java
+++ b/src/main/java/be/woutschoovaerts/mollie/data/refund/RefundResponse.java
@@ -9,7 +9,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-import java.util.Date;
+import java.time.OffsetDateTime;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Optional;
@@ -42,7 +42,7 @@ public class RefundResponse {
 
     private Optional<String> orderId = Optional.empty();
 
-    private Date createdAt;
+    private OffsetDateTime createdAt;
 
     @JsonProperty("_embedded")
     private Optional<RefundEmbedded> embedded = Optional.empty();

--- a/src/main/java/be/woutschoovaerts/mollie/data/settlement/SettlementResponse.java
+++ b/src/main/java/be/woutschoovaerts/mollie/data/settlement/SettlementResponse.java
@@ -7,7 +7,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-import java.util.Date;
+import java.time.OffsetDateTime;
 import java.util.HashMap;
 
 @Data
@@ -22,9 +22,9 @@ public class SettlementResponse {
 
     private String reference;
 
-    private Date createdAt;
+    private OffsetDateTime createdAt;
 
-    private Date settledAt;
+    private OffsetDateTime settledAt;
 
     private SettlementStatus status;
 

--- a/src/main/java/be/woutschoovaerts/mollie/data/shipment/ShipmentResponse.java
+++ b/src/main/java/be/woutschoovaerts/mollie/data/shipment/ShipmentResponse.java
@@ -7,7 +7,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-import java.util.Date;
+import java.time.OffsetDateTime;
 import java.util.List;
 
 @Data
@@ -22,7 +22,7 @@ public class ShipmentResponse {
 
     private String orderId;
 
-    private Date createdAt;
+    private OffsetDateTime createdAt;
 
     private ShipmentTrackingResponse tracking;
 

--- a/src/main/java/be/woutschoovaerts/mollie/data/subscription/SubscriptionRequest.java
+++ b/src/main/java/be/woutschoovaerts/mollie/data/subscription/SubscriptionRequest.java
@@ -9,7 +9,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-import java.util.Date;
+import java.time.LocalDate;
 import java.util.Map;
 import java.util.Optional;
 
@@ -26,7 +26,7 @@ public class SubscriptionRequest {
     private String interval;
 
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
-    private Optional<Date> startDate = Optional.empty();
+    private Optional<LocalDate> startDate = Optional.empty();
 
     private String description;
 

--- a/src/main/java/be/woutschoovaerts/mollie/data/subscription/SubscriptionResponse.java
+++ b/src/main/java/be/woutschoovaerts/mollie/data/subscription/SubscriptionResponse.java
@@ -10,7 +10,8 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-import java.util.Date;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
 import java.util.Map;
 import java.util.Optional;
 
@@ -26,7 +27,7 @@ public class SubscriptionResponse {
 
     private String mode;
 
-    private Date createdAt;
+    private OffsetDateTime createdAt;
 
     private SubscriptionStatus status;
 
@@ -38,9 +39,9 @@ public class SubscriptionResponse {
 
     private String interval;
 
-    private Date startDate;
+    private LocalDate startDate;
 
-    private Optional<Date> nextPaymentDate = Optional.empty();
+    private Optional<LocalDate> nextPaymentDate = Optional.empty();
 
     private String description;
 
@@ -48,7 +49,7 @@ public class SubscriptionResponse {
 
     private Optional<String> mandateId = Optional.empty();
 
-    private Date canceledAt;
+    private OffsetDateTime canceledAt;
 
     private String webhookUrl;
 

--- a/src/main/java/be/woutschoovaerts/mollie/data/subscription/UpdateSubscriptionRequest.java
+++ b/src/main/java/be/woutschoovaerts/mollie/data/subscription/UpdateSubscriptionRequest.java
@@ -7,7 +7,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-import java.util.Date;
+import java.time.LocalDate;
 import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalInt;
@@ -23,7 +23,7 @@ public class UpdateSubscriptionRequest {
     private OptionalInt times = OptionalInt.empty();
 
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
-    private Optional<Date> startDate = Optional.empty();
+    private Optional<LocalDate> startDate = Optional.empty();
 
     private Optional<String> description = Optional.empty();
 

--- a/src/main/java/be/woutschoovaerts/mollie/util/ObjectMapperService.java
+++ b/src/main/java/be/woutschoovaerts/mollie/util/ObjectMapperService.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import lombok.Getter;
 
 import java.math.BigDecimal;
@@ -33,5 +34,6 @@ public final class ObjectMapperService {
         mapper.configOverride(BigDecimal.class).setFormat(JsonFormat.Value.forShape(JsonFormat.Shape.STRING));
 
         mapper.registerModule(new Jdk8Module());
+        mapper.registerModule(new JavaTimeModule());
     }
 }

--- a/src/test/java/be/woutschoovaerts/mollie/handler/MandateHandlerIntegrationTest.java
+++ b/src/test/java/be/woutschoovaerts/mollie/handler/MandateHandlerIntegrationTest.java
@@ -14,7 +14,7 @@ import org.apache.commons.lang3.RandomUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.util.Date;
+import java.time.LocalDate;
 import java.util.Optional;
 
 import static be.woutschoovaerts.mollie.IntegrationTestConstants.API_KEY;
@@ -100,7 +100,7 @@ class MandateHandlerIntegrationTest {
                 .consumerName("John Doe")
                 .consumerAccount("NL55INGB0000000000")
                 .consumerBic(Optional.of("INGBNL2A"))
-                .signatureDate(Optional.of(new Date()))
+                .signatureDate(Optional.of(LocalDate.now()))
                 .mandateReference(Optional.of("YOUR-COMPANY-MD13804"))
                 .build();
 

--- a/src/test/java/be/woutschoovaerts/mollie/handler/SubscriptionHandlerIntegrationTest.java
+++ b/src/test/java/be/woutschoovaerts/mollie/handler/SubscriptionHandlerIntegrationTest.java
@@ -19,7 +19,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
-import java.util.Date;
+import java.time.LocalDate;
 import java.util.Optional;
 
 import static be.woutschoovaerts.mollie.IntegrationTestConstants.API_KEY;
@@ -140,7 +140,7 @@ class SubscriptionHandlerIntegrationTest {
                 .consumerName("John Doe")
                 .consumerAccount("NL55INGB0000000000")
                 .consumerBic(Optional.of("INGBNL2A"))
-                .signatureDate(Optional.of(new Date()))
+                .signatureDate(Optional.of(LocalDate.now()))
                 .mandateReference(Optional.of("YOUR-COMPANY-MD13804"))
                 .build();
 


### PR DESCRIPTION
I have changed all java.util.Date to its java.time representatives according to Mollie documentation - based on what date format is required for each API call. 