### PR TITLE
Added interval and mandateId to UpdateSubscriptionRequest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.4.1
+- Added missing fields to 'UpdateSubscriptionRequest'
+
 ## 3.4.0
 - Changed `java.util.Date` fields to its `java.time` representatives
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -4,3 +4,4 @@
 - [Tom Martens](https://github.com/tomsnor)
 - [Dániel Szabó](https://github.com/szada92)
 - [Tim Smelik](https://github.com/timsmelik)
+- [Thomas van Putten](https://github.com/delta11)

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>be.woutschoovaerts</groupId>
     <artifactId>mollie</artifactId>
-    <version>3.4.0</version>
+    <version>3.4.1</version>
 
     <name>Mollie with Java</name>
     <description>Java framework to consume the Mollie API</description>

--- a/src/main/java/be/woutschoovaerts/mollie/data/subscription/UpdateSubscriptionRequest.java
+++ b/src/main/java/be/woutschoovaerts/mollie/data/subscription/UpdateSubscriptionRequest.java
@@ -27,6 +27,10 @@ public class UpdateSubscriptionRequest {
 
     private Optional<String> description = Optional.empty();
 
+    private Optional<String> interval = Optional.empty();
+
+    private Optional<String> mandateId = Optional.empty();
+
     private Optional<String> webhookUrl = Optional.empty();
 
     private Map<String, Object> metadata;


### PR DESCRIPTION
I've added interval and mandateId to UpdateSubscriptionRequest so that the type comes back in line with the documentation:  https://docs.mollie.com/reference/v2/subscriptions-api/update-subscription