### PR TITLE
Updated Log4j to 2.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.5.0
+- Updated Log4j to 2.16.0
+- Bumped all other dependencies and made their versions a property
+
 ## 3.4.0
 - Changed `java.util.Date` fields to its `java.time` representatives
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This library requires Java 8+.
 <dependency>
     <groupId>be.woutschoovaerts</groupId>
     <artifactId>mollie</artifactId>
-    <version>3.4.0</version>
+    <version>3.5.0</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>be.woutschoovaerts</groupId>
     <artifactId>mollie</artifactId>
-    <version>3.4.0</version>
+    <version>3.5.0</version>
 
     <name>Mollie with Java</name>
     <description>Java framework to consume the Mollie API</description>
@@ -35,10 +35,20 @@
     </scm>
 
     <properties>
-        <jackson.version>2.12.1</jackson.version>
-        <log4j.version>2.11.1</log4j.version>
+        <commons-lang3.version>3.12.0</commons-lang3.version>
+        <jackson.version>2.13.0</jackson.version>
         <java.version>1.8</java.version>
+        <jaxb-api.version>2.4.0-b180830.0359</jaxb-api.version>
+        <jaxb-core.version>3.0.1</jaxb-core.version>
+        <junit-jupiter-engine.version>5.8.2</junit-jupiter-engine.version>
+        <log4j.version>2.16.0</log4j.version>
+        <lombok.version>1.18.22</lombok.version>
+        <lombok-maven-plugin.version>1.18.0.0</lombok-maven-plugin.version>
+        <maven-jdk-tools-wrapper.version>0.1</maven-jdk-tools-wrapper.version>
+        <mockito-core.version>4.1.0</mockito-core.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <slf4j-api.version>1.7.32</slf4j-api.version>
+        <unirest-java.version>3.13.4</unirest-java.version>
     </properties>
 
     <dependencies>
@@ -48,14 +58,14 @@
         <dependency>
             <groupId>com.konghq</groupId>
             <artifactId>unirest-java</artifactId>
-            <version>3.6.01</version>
+            <version>${unirest-java.version}</version>
             <scope>compile</scope>
         </dependency>
 
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.2</version>
+            <version>${lombok.version}</version>
             <scope>provided</scope>
         </dependency>
 
@@ -86,53 +96,53 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.8</version>
+            <version>${commons-lang3.version}</version>
         </dependency>
 
         <!-- Logging -->
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>1.7.28</version>
+            <version>${slf4j-api.version}</version>
         </dependency>
 
         <!-- Needed for Java 9+ -->
         <dependency>
             <groupId>javax.xml.bind</groupId>
             <artifactId>jaxb-api</artifactId>
-            <version>2.4.0-b180725.0427</version>
+            <version>${jaxb-api.version}</version>
         </dependency>
 
         <dependency>
             <groupId>com.sun.xml.bind</groupId>
             <artifactId>jaxb-impl</artifactId>
-            <version>2.4.0-b180725.0644</version>
+            <version>${jaxb-core.version}</version>
         </dependency>
 
         <dependency>
             <groupId>com.sun.xml.bind</groupId>
             <artifactId>jaxb-core</artifactId>
-            <version>2.3.0.1</version>
+            <version>${jaxb-core.version}</version>
         </dependency>
 
         <dependency>
             <groupId>com.github.olivergondza</groupId>
             <artifactId>maven-jdk-tools-wrapper</artifactId>
-            <version>0.1</version>
+            <version>${maven-jdk-tools-wrapper.version}</version>
         </dependency>
 
         <!-- Test dependencies -->
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <version>5.5.1</version>
+            <version>${junit-jupiter-engine.version}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>2.21.0</version>
+            <version>${mockito-core.version}</version>
             <scope>test</scope>
         </dependency>
 
@@ -239,7 +249,7 @@
             <plugin>
                 <groupId>org.projectlombok</groupId>
                 <artifactId>lombok-maven-plugin</artifactId>
-                <version>1.18.0.0</version>
+                <version>${lombok-maven-plugin.version}</version>
                 <configuration>
                     <sourceDirectory>src/main/java</sourceDirectory>
                     <outputDirectory>${project.build.directory}/delombok</outputDirectory>
@@ -300,6 +310,19 @@
                     </plugin>
                 </plugins>
             </build>
+        </profile>
+        <profile>
+            <id>java11+</id>
+            <activation>
+                <jdk>[11,)</jdk>
+            </activation>
+            <properties>
+                <!--
+                Workaround for "javadoc: error - The code being documented uses modules but the packages
+                defined in https://docs.oracle.com/javase/8/docs/api/ are in the unnamed module."
+                -->
+                <maven.javadoc.skip>true</maven.javadoc.skip>
+            </properties>
         </profile>
     </profiles>
 


### PR DESCRIPTION
- Bumped all other dependencies and made their versions a property

Although Log4j was only used for tests I decided it would be wise to update to 2.15.0 anyways