### PR TITLE
Add support for the chargeback reason field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.7.0
+ - Add support for the chargeback reason field
+
 ## 3.6.8
  - Sending testmode as boolean instead of String
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -5,3 +5,4 @@
 - [Dániel Szabó](https://github.com/szada92)
 - [Tim Smelik](https://github.com/timsmelik)
 - [Thomas van Putten](https://github.com/delta11)
+- [Robbert-Jan Roos](https://github.com/rjroos)

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This library requires Java 8+.
 <dependency>
     <groupId>be.woutschoovaerts</groupId>
     <artifactId>mollie</artifactId>
-    <version>3.6.8</version>
+    <version>3.7.0</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>be.woutschoovaerts</groupId>
     <artifactId>mollie</artifactId>
-    <version>3.6.8</version>
+    <version>3.7.0</version>
 
     <name>Mollie with Java</name>
     <description>Java framework to consume the Mollie API</description>

--- a/src/main/java/be/woutschoovaerts/mollie/data/chargeback/ChargebackReason.java
+++ b/src/main/java/be/woutschoovaerts/mollie/data/chargeback/ChargebackReason.java
@@ -1,0 +1,18 @@
+package be.woutschoovaerts.mollie.data.chargeback;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class ChargebackReason {
+
+    private String code;
+
+    private String description;
+
+}

--- a/src/main/java/be/woutschoovaerts/mollie/data/chargeback/ChargebackResponse.java
+++ b/src/main/java/be/woutschoovaerts/mollie/data/chargeback/ChargebackResponse.java
@@ -27,6 +27,8 @@ public class ChargebackResponse {
 
     private OffsetDateTime createdAt;
 
+    private ChargebackReason reason;
+
     private OffsetDateTime reversedAt;
 
     private String paymentId;

--- a/src/main/java/be/woutschoovaerts/mollie/data/chargeback/ChargebackResponse.java
+++ b/src/main/java/be/woutschoovaerts/mollie/data/chargeback/ChargebackResponse.java
@@ -27,7 +27,7 @@ public class ChargebackResponse {
 
     private OffsetDateTime createdAt;
 
-    private ChargebackReason reason;
+    private Optional<ChargebackReason> reason;
 
     private OffsetDateTime reversedAt;
 


### PR DESCRIPTION
Hi,

The Mollie API exposes a "reason" field for chargebacks. This is filled for Dutch direct debits.
https://docs.mollie.com/reference/v2/chargebacks-api/get-payment-chargeback

With this pull request this information is also available in java.

I could not figure out a nice way to unit test it unfortunately. It does work on my computer ;-)

Regards,

Robbert-Jan