### PR TITLE
Initialize Chargeback.reason with Optional.empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.7.1
+ - Make chargeback reason a working Optional instead of null.
+
 ## 3.7.0
  - Add support for the chargeback reason field
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This library requires Java 8+.
 <dependency>
     <groupId>be.woutschoovaerts</groupId>
     <artifactId>mollie</artifactId>
-    <version>3.7.0</version>
+    <version>3.7.1</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>be.woutschoovaerts</groupId>
     <artifactId>mollie</artifactId>
-    <version>3.7.0</version>
+    <version>3.7.1</version>
 
     <name>Mollie with Java</name>
     <description>Java framework to consume the Mollie API</description>

--- a/src/main/java/be/woutschoovaerts/mollie/data/chargeback/ChargebackResponse.java
+++ b/src/main/java/be/woutschoovaerts/mollie/data/chargeback/ChargebackResponse.java
@@ -27,7 +27,7 @@ public class ChargebackResponse {
 
     private OffsetDateTime createdAt;
 
-    private Optional<ChargebackReason> reason;
+    private Optional<ChargebackReason> reason = Optional.empty();
 
     private OffsetDateTime reversedAt;
 

--- a/src/test/java/be/woutschoovaerts/mollie/data/chargeback/ChargebackResponseTest.java
+++ b/src/test/java/be/woutschoovaerts/mollie/data/chargeback/ChargebackResponseTest.java
@@ -1,0 +1,39 @@
+package be.woutschoovaerts.mollie.data.chargeback;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import org.junit.jupiter.api.Test;
+
+import be.woutschoovaerts.mollie.util.ObjectMapperService;
+import com.fasterxml.jackson.core.type.TypeReference;
+
+class ChargebackResponseTest {
+
+	@Test
+	public void testChargebackWithReason() throws IOException {
+		ChargebackResponse cb = parse("chargeback-with-reason.json");
+		assertEquals("AM04", cb.getReason().get().getCode(), "reason.code");
+		assertEquals("Insufficient funds", cb.getReason().get().getDescription(), "reason.description");
+	}
+	
+	@Test
+	public void testChargebackWithoutReason() throws IOException {
+		ChargebackResponse cb = parse("chargeback-without-reason.json");
+		assertFalse(cb.getReason().isPresent(), "reason");
+	}
+	
+	private ChargebackResponse parse(String resourcename) throws IOException {
+		try (InputStream is = getClass().getResourceAsStream(resourcename)) {
+			assertNotNull(is, "resource " + resourcename + " not found");
+			return ObjectMapperService.getInstance().getMapper().readValue(is,
+                    new TypeReference<ChargebackResponse>() {
+                    });
+		}
+	}
+
+}

--- a/src/test/java/be/woutschoovaerts/mollie/data/chargeback/chargeback-with-reason.json
+++ b/src/test/java/be/woutschoovaerts/mollie/data/chargeback/chargeback-with-reason.json
@@ -1,0 +1,33 @@
+{
+  "resource": "chargeback",
+  "id": "chb_aaaaaa",
+  "amount": {
+    "value": "15.00",
+    "currency": "EUR"
+  },
+  "createdAt": "2019-10-29T04:38:24+00:00",
+  "reason": {
+    "code": "AM04",
+    "description": "Insufficient funds"
+  },
+  "paymentId": "tr_aaaaaaaaa",
+  "settlementId": "stl_aaaaaaaaa",
+  "settlementAmount": {
+    "value": "-15.00",
+    "currency": "EUR"
+  },
+  "_links": {
+    "self": {
+      "href": "https://api.mollie.com/v2/payments/tr_aaaaaaaaa/chargebacks/chb_aaaaaa",
+      "type": "application/hal+json"
+    },
+    "payment": {
+      "href": "https://api.mollie.com/v2/payments/tr_aaaaaaaaa",
+      "type": "application/hal+json"
+    },
+    "settlement": {
+      "href": "https://api.mollie.com/v2/settlements/stl_aaaaaaaaa",
+      "type": "application/hal+json"
+    }
+  }
+}

--- a/src/test/java/be/woutschoovaerts/mollie/data/chargeback/chargeback-without-reason.json
+++ b/src/test/java/be/woutschoovaerts/mollie/data/chargeback/chargeback-without-reason.json
@@ -1,0 +1,29 @@
+{
+  "resource": "chargeback",
+  "id": "chb_aaaaaa",
+  "amount": {
+    "value": "15.00",
+    "currency": "EUR"
+  },
+  "createdAt": "2019-10-29T04:38:24+00:00",
+  "paymentId": "tr_aaaaaaaaa",
+  "settlementId": "stl_aaaaaaaaa",
+  "settlementAmount": {
+    "value": "-15.00",
+    "currency": "EUR"
+  },
+  "_links": {
+    "self": {
+      "href": "https://api.mollie.com/v2/payments/tr_aaaaaaaaa/chargebacks/chb_aaaaaa",
+      "type": "application/hal+json"
+    },
+    "payment": {
+      "href": "https://api.mollie.com/v2/payments/tr_aaaaaaaaa",
+      "type": "application/hal+json"
+    },
+    "settlement": {
+      "href": "https://api.mollie.com/v2/settlements/stl_aaaaaaaaa",
+      "type": "application/hal+json"
+    }
+  }
+}


### PR DESCRIPTION
Sorry to bother you again, but the getReason() I added returned null on absent reasons, which is confusing.

Attached the fix and a unit test for both cases.
