### PR TITLE
Use HTTP `DELETE` for revoking tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This library requires Java 11+.
 <dependency>
     <groupId>be.woutschoovaerts</groupId>
     <artifactId>mollie</artifactId>
-    <version>4.2.0</version>
+    <version>4.2.1</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>be.woutschoovaerts</groupId>
     <artifactId>mollie</artifactId>
-    <version>4.2.0</version>
+    <version>4.2.1</version>
 
     <name>Mollie with Java</name>
     <description>Java framework to consume the Mollie API</description>

--- a/src/main/java/be/woutschoovaerts/mollie/handler/connect/OAuthHandler.java
+++ b/src/main/java/be/woutschoovaerts/mollie/handler/connect/OAuthHandler.java
@@ -118,7 +118,7 @@ public class OAuthHandler {
             String url = "https://api.mollie.com/oauth2/tokens" + params.toString();
 
             log.info("Executing 'DELETE {}'", url);
-            HttpResponse<String> response = Unirest.post(url)
+            HttpResponse<String> response = Unirest.delete(url)
                     .header("Content-Type", "application/x-www-form-urlencoded")
                     .basicAuth(clientId, clientSecret)
                     .body(getRevokeTokenBody(body))


### PR DESCRIPTION
When revoking a token, HTTP `DELETE` is to be used. See https://docs.mollie.com/reference/oauth2/revoke-token