### PR TITLE
Added missing parameters in Profiles endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.2.1
+ - Added parameters "description" and "countriesOfActivity" to ProfileRequest
+ - Added parameters "description" and "countriesOfActivity" to UpdateProfileRequest
+ 
 ## 4.2.0
  - Add support for payment method TWINT in payment API
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -10,3 +10,4 @@
 - [Nils Bokdam](https://github.com/nbokdam)
 - [Niek Knuiman](https://github.com/niek1414)
 - [Jan Allenberg](https://github.com/JanAllenberg)
+- [Lukas Deterts](https://github.com/lukasdeterts)

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This library requires Java 11+.
 <dependency>
     <groupId>be.woutschoovaerts</groupId>
     <artifactId>mollie</artifactId>
-    <version>4.2.0</version>
+    <version>4.2.1</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>be.woutschoovaerts</groupId>
     <artifactId>mollie</artifactId>
-    <version>4.2.0</version>
+    <version>4.2.1</version>
 
     <name>Mollie with Java</name>
     <description>Java framework to consume the Mollie API</description>

--- a/src/main/java/be/woutschoovaerts/mollie/data/profile/ProfileRequest.java
+++ b/src/main/java/be/woutschoovaerts/mollie/data/profile/ProfileRequest.java
@@ -34,9 +34,9 @@ public class ProfileRequest {
     @Builder.Default
     private Optional<String> mode = Optional.empty();
 
-	@Builder.Default
-	private Optional<String> description = Optional.empty();
+    @Builder.Default
+    private Optional<String> description = Optional.empty();
 
-	@Builder.Default
-	private Optional<String[]> countriesOfActivity = Optional.empty();
+    @Builder.Default
+    private Optional<String[]> countriesOfActivity = Optional.empty();
 }

--- a/src/main/java/be/woutschoovaerts/mollie/data/profile/ProfileRequest.java
+++ b/src/main/java/be/woutschoovaerts/mollie/data/profile/ProfileRequest.java
@@ -33,4 +33,10 @@ public class ProfileRequest {
 
     @Builder.Default
     private Optional<String> mode = Optional.empty();
+
+	@Builder.Default
+	private Optional<String> description = Optional.empty();
+
+	@Builder.Default
+	private Optional<String[]> countriesOfActivity = Optional.empty();
 }

--- a/src/main/java/be/woutschoovaerts/mollie/data/profile/UpdateProfileRequest.java
+++ b/src/main/java/be/woutschoovaerts/mollie/data/profile/UpdateProfileRequest.java
@@ -38,9 +38,9 @@ public class UpdateProfileRequest {
     @Builder.Default
     private Optional<String> mode = Optional.empty();
 
-	@Builder.Default
-	private Optional<String> description = Optional.empty();
+    @Builder.Default
+    private Optional<String> description = Optional.empty();
 
-	@Builder.Default
-	private Optional<String[]> countriesOfActivity = Optional.empty();
+    @Builder.Default
+    private Optional<String[]> countriesOfActivity = Optional.empty();
 }

--- a/src/main/java/be/woutschoovaerts/mollie/data/profile/UpdateProfileRequest.java
+++ b/src/main/java/be/woutschoovaerts/mollie/data/profile/UpdateProfileRequest.java
@@ -37,4 +37,10 @@ public class UpdateProfileRequest {
 
     @Builder.Default
     private Optional<String> mode = Optional.empty();
+
+	@Builder.Default
+	private Optional<String> description = Optional.empty();
+
+	@Builder.Default
+	private Optional<String[]> countriesOfActivity = Optional.empty();
 }


### PR DESCRIPTION
I added the two parameters "description" and "countriesOfActivity" into the two classes ProfileRequest.java and UpdateProfileRequest.java.

For reference, here are the specific endpoints in the API-documentation:
https://docs.mollie.com/reference/v2/profiles-api/update-profile
https://docs.mollie.com/reference/v2/profiles-api/create-profile