### PR TITLE
Add support for new payment method TRUSTLY

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 4.3.1
+- Added support for TRUSTLY in payment API
+
 ## 4.3.0
  - Added Terminals API
  - Added parameters "description" and "countriesOfActivity" to ProfileRequest

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -11,3 +11,4 @@
 - [Niek Knuiman](https://github.com/niek1414)
 - [Jan Allenberg](https://github.com/JanAllenberg)
 - [Lukas Deterts](https://github.com/lukasdeterts)
+- [Daniel Krax](https://github.com/sharktoon)

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This library requires Java 11+.
 <dependency>
     <groupId>be.woutschoovaerts</groupId>
     <artifactId>mollie</artifactId>
-    <version>4.3.0</version>
+    <version>4.3.1</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>be.woutschoovaerts</groupId>
     <artifactId>mollie</artifactId>
-    <version>4.3.0</version>
+    <version>4.3.1</version>
 
     <name>Mollie with Java</name>
     <description>Java framework to consume the Mollie API</description>

--- a/src/main/java/be/woutschoovaerts/mollie/data/payment/PaymentMethod.java
+++ b/src/main/java/be/woutschoovaerts/mollie/data/payment/PaymentMethod.java
@@ -27,6 +27,7 @@ public enum PaymentMethod {
     PAY_SAFE_CARD("paysafecard"),
     PRZELEWY24("przelewy24"),
     SOFORT("sofort"),
+    TRUSTLY("trustly"),
     TWINT("twint"),
     VOUCHER("voucher"),
     POINT_OFF_SALE("pointofsale");


### PR DESCRIPTION
Trustly was recently implemented as a replacement for Giropay. This makes it available as part of the PaymentMethods enum.