### PR TITLE
Tests can change base url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 4.3.1
+- add ability to set a base url for testing - e.g. using wiremock
+
 ## 4.3.0
  - Added Terminals API
  - Added parameters "description" and "countriesOfActivity" to ProfileRequest

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -11,3 +11,4 @@
 - [Niek Knuiman](https://github.com/niek1414)
 - [Jan Allenberg](https://github.com/JanAllenberg)
 - [Lukas Deterts](https://github.com/lukasdeterts)
+- [Daniel Krax](https://github.com/sharktoon)

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This library requires Java 11+.
 <dependency>
     <groupId>be.woutschoovaerts</groupId>
     <artifactId>mollie</artifactId>
-    <version>4.3.0</version>
+    <version>4.3.1</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>be.woutschoovaerts</groupId>
     <artifactId>mollie</artifactId>
-    <version>4.3.0</version>
+    <version>4.3.1</version>
 
     <name>Mollie with Java</name>
     <description>Java framework to consume the Mollie API</description>

--- a/src/main/java/be/woutschoovaerts/mollie/Client.java
+++ b/src/main/java/be/woutschoovaerts/mollie/Client.java
@@ -15,7 +15,6 @@ import be.woutschoovaerts.mollie.util.Config;
 import be.woutschoovaerts.mollie.util.RestService;
 import kong.unirest.Unirest;
 import lombok.Getter;
-import org.apache.commons.lang3.StringUtils;
 
 public class Client {
 

--- a/src/main/java/be/woutschoovaerts/mollie/Client.java
+++ b/src/main/java/be/woutschoovaerts/mollie/Client.java
@@ -15,6 +15,7 @@ import be.woutschoovaerts.mollie.util.Config;
 import be.woutschoovaerts.mollie.util.RestService;
 import kong.unirest.Unirest;
 import lombok.Getter;
+import org.apache.commons.lang3.StringUtils;
 
 public class Client {
 
@@ -34,6 +35,7 @@ public class Client {
         config.setAccessToken(null);
         config.setTestMode(false);
         config.setIdempotencyKey(null);
+        config.setBaseUrl(null);
 
         restService = new RestService(config);
 
@@ -85,6 +87,22 @@ public class Client {
      */
     public void setUserAgentString(String userAgentString) {
         config.setUserAgentString(userAgentString);
+    }
+
+    /**
+     * Only needed for testing purposes - Overrides base url
+     * @param baseUrl A replacement base url - e. g. the wiremock url
+     */
+    public void setBaseUrl(String baseUrl) {
+        String urlWithNoTrailingSlashes = baseUrl == null ? null : baseUrl.replaceAll("/*$", "");
+        config.setBaseUrl(urlWithNoTrailingSlashes);
+    }
+
+    /**
+     * removes any previously overridden base url and uses the actual mollie url
+     */
+    public void setRealBaseUrl() {
+        config.setBaseUrl(null);
     }
 
     /**

--- a/src/main/java/be/woutschoovaerts/mollie/util/Config.java
+++ b/src/main/java/be/woutschoovaerts/mollie/util/Config.java
@@ -26,6 +26,9 @@ public final class Config {
     @Setter
     private String idempotencyKey;
 
+    @Setter
+    private String baseUrl;
+
     public String getBearerToken() {
         return StringUtils.isBlank(accessToken) ? apiKey : accessToken;
     }
@@ -40,5 +43,9 @@ public final class Config {
 
     public Optional<String> getIdempotencyKey() {
         return StringUtils.isNotBlank(idempotencyKey) ? Optional.of(idempotencyKey) : Optional.empty();
+    }
+
+    public Optional<String> getBaseUrl() {
+        return StringUtils.isNotBlank(baseUrl) ? Optional.of(baseUrl) : Optional.empty();
     }
 }

--- a/src/main/java/be/woutschoovaerts/mollie/util/RestService.java
+++ b/src/main/java/be/woutschoovaerts/mollie/util/RestService.java
@@ -14,7 +14,7 @@ import java.util.Map;
 @Slf4j
 public class RestService {
 
-    private static final String BASE_URL = "https://api.mollie.com/v2";
+    private static final String REAL_BASE_URL = "https://api.mollie.com/v2";
 
     private final ObjectMapper mapper;
     private final Config config;
@@ -38,7 +38,7 @@ public class RestService {
             params.put("testmode", "true");
         }
 
-        String url = BASE_URL + uri + params.toString();
+        String url = getBaseUrl() + uri + params.toString();
 
         log.info("Executing 'GET {}'", url);
 
@@ -56,7 +56,7 @@ public class RestService {
 
     public <T> T postWithoutBody(String uri, QueryParams params, TypeReference<T> typeRef)
             throws IOException, MollieException {
-        String url = BASE_URL + uri + params.toString();
+        String url = getBaseUrl() + uri + params.toString();
 
         log.info("Executing 'POST {}'", url);
 
@@ -77,7 +77,7 @@ public class RestService {
 
     public <T> T post(String uri, Object body, QueryParams params, TypeReference<T> typeRef)
             throws IOException, MollieException {
-        String url = BASE_URL + uri + params.toString();
+        String url = getBaseUrl() + uri + params.toString();
 
         log.info("Executing 'POST {}'", url);
 
@@ -99,7 +99,7 @@ public class RestService {
 
     public <T> T patch(String uri, Object body, QueryParams params, TypeReference<T> typeRef)
             throws IOException, MollieException {
-        String url = BASE_URL + uri + params.toString();
+        String url = getBaseUrl() + uri + params.toString();
 
         log.info("Executing 'PATCH {}'", url);
 
@@ -130,7 +130,7 @@ public class RestService {
             body.put("testmode", true);
         }
 
-        String url = BASE_URL + uri + params.toString();
+        String url = getBaseUrl() + uri + params.toString();
 
         log.info("Executing 'DELETE {}'", url);
 
@@ -148,7 +148,7 @@ public class RestService {
 
     public <T> T delete(String uri, Object body, QueryParams params, TypeReference<T> typeRef)
             throws IOException, MollieException {
-        String url = BASE_URL + uri + params.toString();
+        String url = getBaseUrl() + uri + params.toString();
 
         log.info("Executing 'DELETE {}'", url);
 
@@ -193,4 +193,9 @@ public class RestService {
 
         return ObjectMapperService.getInstance().getMapper().readValue(body, typeRef);
     }
+
+    private String getBaseUrl() {
+        return config.getBaseUrl().orElse(REAL_BASE_URL);
+    }
+
 }

--- a/src/test/java/be/woutschoovaerts/mollie/ClientTest.java
+++ b/src/test/java/be/woutschoovaerts/mollie/ClientTest.java
@@ -85,6 +85,32 @@ class ClientTest {
     }
 
     @Test
+    void setBaseUrl() {
+        Client client = new Client("apiKey");
+        assertEquals(Optional.empty(), client.getConfig().getBaseUrl());
+
+        client.setBaseUrl("http://localhost:1234/");
+
+        assertEquals(Optional.of("http://localhost:1234"), client.getConfig().getBaseUrl());
+
+        Unirest.config().shutDown(true);
+    }
+
+    @Test
+    void unsetBaseUrl() {
+        Client client = new Client("apiKey");
+        client.setBaseUrl("http://localhost:1234");
+
+        assertEquals(Optional.of("http://localhost:1234"), client.getConfig().getBaseUrl());
+
+        client.setRealBaseUrl();
+
+        assertEquals(Optional.empty(), client.getConfig().getBaseUrl());
+
+        Unirest.config().shutDown(true);
+    }
+
+    @Test
     void twoClients() {
         Client client1 = new Client("apiKey1");
         Client client2 = new Client("apiKey2");


### PR DESCRIPTION
While trying to set up tests with Wiremock, we needed to configure a different baseurl.

This proposal changes the way RestClient handles the BASE_URL. It is possible to set a base url using the Config-Instance.

By default, the Config's base url is `null` and RestClient uses the REAL_BASE_URL - previously just BASE_URL. However, if there's an override url available, RestClient uses that.

The setters automatically strip away trailing slashes. The hope is that this prevents weird mistakes when setting such an url.