### PR TITLE
IMP-610: Use correct OAuth authorize URL

### DIFF
--- a/src/main/java/be/woutschoovaerts/mollie/handler/connect/OAuthHandler.java
+++ b/src/main/java/be/woutschoovaerts/mollie/handler/connect/OAuthHandler.java
@@ -41,7 +41,7 @@ public class OAuthHandler {
      * @return The authorize URL
      */
     public String createAuthorizeUrl(AuthorizeRequest request) {
-        return "https://www.mollie.com/oauth2/authorize" + convertAuthorizeRequestToQueryParams(request).toString();
+        return "https://my.mollie.com/oauth2/authorize" + convertAuthorizeRequestToQueryParams(request).toString();
     }
 
     /**

--- a/src/test/java/be/woutschoovaerts/mollie/handler/connect/OAuthHandlerTest.java
+++ b/src/test/java/be/woutschoovaerts/mollie/handler/connect/OAuthHandlerTest.java
@@ -25,7 +25,7 @@ class OAuthHandlerTest {
 
     @Test
     void createAuthorizeUrl() {
-        String expected = "https://www.mollie.com/oauth2/authorize?client_id=client_id&redirect_uri=https%3A%2F%2Fz-soft.be&state=state&scope=scope1+scope2&response_type=code&approval_prompt=auto";
+        String expected = "https://my.mollie.com/oauth2/authorize?client_id=client_id&redirect_uri=https%3A%2F%2Fz-soft.be&state=state&scope=scope1+scope2&response_type=code&approval_prompt=auto";
 
         AuthorizeRequest request = AuthorizeRequest.builder()
                 .clientId("client_id")

--- a/src/test/java/be/woutschoovaerts/mollie/integration/handler/connect/OAuthHandlerIntegrationTest.java
+++ b/src/test/java/be/woutschoovaerts/mollie/integration/handler/connect/OAuthHandlerIntegrationTest.java
@@ -14,7 +14,7 @@ import static be.woutschoovaerts.mollie.IntegrationTestConstants.API_KEY;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-//https://www.mollie.com/oauth2/authorize?client_id=*client_id*&state=random&scope=payments.read&response_type=code&approval_prompt=auto
+//https://my.mollie.com/oauth2/authorize?client_id=*client_id*&state=random&scope=payments.read&response_type=code&approval_prompt=auto
 
 class OAuthHandlerIntegrationTest {
 
@@ -36,7 +36,7 @@ class OAuthHandlerIntegrationTest {
                 .approvalPrompt(ApprovalPrompt.AUTO)
                 .build();
 
-        String expected = "https://www.mollie.com/oauth2/authorize?client_id=client_123" +
+        String expected = "https://my.mollie.com/oauth2/authorize?client_id=client_123" +
                 "&redirect_uri=https%3A%2F%2Fgoogle.be&state=ABC&scope=scope1+scope2" +
                 "&response_type=code&approval_prompt=auto";
 
@@ -53,7 +53,7 @@ class OAuthHandlerIntegrationTest {
                 .approvalPrompt(ApprovalPrompt.AUTO)
                 .build();
 
-        String expected = "https://www.mollie.com/oauth2/authorize?client_id=client_123" +
+        String expected = "https://my.mollie.com/oauth2/authorize?client_id=client_123" +
                 "&state=ABC&scope=scope1+scope2&response_type=code&approval_prompt=auto";
 
         assertEquals(expected, client.oAuth().createAuthorizeUrl(request));


### PR DESCRIPTION
The OAuth authorize URL has changed from www.mollie.com to my.mollie.com. This is to reflect this change