### PR TITLE
Add missing mapping for mobileAppCheckout in PaymentLinks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 4.4.1
+- Added "mobileAppCheckout" mapping in PaymentLinks
+
 ## 4.3.1
 - Added support for TRUSTLY in payment API
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This library requires Java 11+.
 <dependency>
     <groupId>be.woutschoovaerts</groupId>
     <artifactId>mollie</artifactId>
-    <version>4.4.0</version>
+    <version>4.4.1</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>be.woutschoovaerts</groupId>
     <artifactId>mollie</artifactId>
-    <version>4.4.0</version>
+    <version>4.4.1</version>
 
     <name>Mollie with Java</name>
     <description>Java framework to consume the Mollie API</description>

--- a/src/main/java/be/woutschoovaerts/mollie/data/payment/PaymentLinks.java
+++ b/src/main/java/be/woutschoovaerts/mollie/data/payment/PaymentLinks.java
@@ -41,4 +41,6 @@ public class PaymentLinks {
     private Optional<Link> payOnline = Optional.empty();
 
     private Optional<Link> changePaymentState = Optional.empty();
+
+    private Optional<Link> mobileAppCheckout = Optional.empty();
 }


### PR DESCRIPTION
Add missing mapping for bancontact mobile payments "mobileAppCheckout". This is needed to start the payment flow in the bancontact app.