### PR TITLE
Consistently use `Map` instead of `HashMap` in Request and Response class member type declarations

### DIFF
--- a/src/main/java/be/woutschoovaerts/mollie/data/refund/RefundRequest.java
+++ b/src/main/java/be/woutschoovaerts/mollie/data/refund/RefundRequest.java
@@ -9,6 +9,7 @@ import lombok.NoArgsConstructor;
 
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 @Data
@@ -22,7 +23,8 @@ public class RefundRequest {
 
     private Amount amount;
 
-    private HashMap<String, Object> metadata;
+    @Builder.Default
+    private Map<String, Object> metadata = new HashMap<>();
 
     @Builder.Default
     private Optional<Boolean> reverseRouting = Optional.empty();

--- a/src/main/java/be/woutschoovaerts/mollie/data/refund/RefundResponse.java
+++ b/src/main/java/be/woutschoovaerts/mollie/data/refund/RefundResponse.java
@@ -13,6 +13,7 @@ import lombok.NoArgsConstructor;
 import java.time.OffsetDateTime;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 @Data
@@ -34,7 +35,8 @@ public class RefundResponse {
     @Builder.Default
     private Optional<Amount> settlementAmount = Optional.empty();
 
-    private HashMap<String, Object> metadata;
+    @Builder.Default
+    private Map<String, Object> metadata = new HashMap<>();
 
     private RefundStatus status;
 

--- a/src/main/java/be/woutschoovaerts/mollie/data/settlement/SettlementResponse.java
+++ b/src/main/java/be/woutschoovaerts/mollie/data/settlement/SettlementResponse.java
@@ -8,7 +8,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 import java.time.OffsetDateTime;
-import java.util.HashMap;
+import java.util.Map;
 
 @Data
 @AllArgsConstructor
@@ -30,7 +30,7 @@ public class SettlementResponse {
 
     private String balanceId;
 
-    private HashMap<Integer, HashMap<Integer, PeriodResponse>> periods;
+    private Map<Integer, Map<Integer, PeriodResponse>> periods;
 
     @JsonProperty("_links")
     private SettlementLinks links;


### PR DESCRIPTION
I noticed some small inconsistency where the concrete `HashMap` was used instead of the interface `Map` in API-level class members (`*Request` and `*Response` classes). 

This forces the API user to use the `HashMap` implementation instead of others. This is an issue especially when used from Kotlin, which has its own implementations of `Map` (and other collection interfaces).