### PR TITLE
129 fix: Rename ClientLinkOwnerRequest owner field to email

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.6.1
+
+- Rename ClientLinkOwnerRequest owner field to email
+
 ## 4.6.0
 
 - Added support for releasing payment authorization

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -12,3 +12,4 @@
 - [Jan Allenberg](https://github.com/JanAllenberg)
 - [Lukas Deterts](https://github.com/lukasdeterts)
 - [Daniel Krax](https://github.com/sharktoon)
+- [Yiannis Sfinias](https://github.com/sfinias)

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This library requires Java 11+.
 <dependency>
     <groupId>be.woutschoovaerts</groupId>
     <artifactId>mollie</artifactId>
-    <version>4.6.0</version>
+    <version>4.6.1</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>be.woutschoovaerts</groupId>
     <artifactId>mollie</artifactId>
-    <version>4.6.0</version>
+    <version>4.6.1</version>
 
     <name>Mollie with Java</name>
     <description>Java framework to consume the Mollie API</description>

--- a/src/main/java/be/woutschoovaerts/mollie/data/client/link/ClientLinkOwnerRequest.java
+++ b/src/main/java/be/woutschoovaerts/mollie/data/client/link/ClientLinkOwnerRequest.java
@@ -14,7 +14,7 @@ import java.util.Optional;
 @Builder
 public class ClientLinkOwnerRequest {
 
-    private String owner;
+    private String email;
     private String givenName;
     private String familyName;
 


### PR DESCRIPTION
Relates to https://github.com/zwaldeck/mollie/issues/129

As per the Client Links API documentation found [here](https://docs.mollie.com/reference/create-client-link), the owner object contains the following fields

- email
-  givenName
- familyName
- locale

In the ClientLinkOwnerRequest though we see that email is in the place of owner. 
This PR amends the name to `email` as the API states.