### PR TITLE
Add 'canceled' status for refunds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.6.1
+
+- Added canceled status for refunds
+
 ## 4.6.0
 
 - Added support for releasing payment authorization

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -12,3 +12,4 @@
 - [Jan Allenberg](https://github.com/JanAllenberg)
 - [Lukas Deterts](https://github.com/lukasdeterts)
 - [Daniel Krax](https://github.com/sharktoon)
+- [Yiannis Sfinias](https://github.com/sfinias)

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>be.woutschoovaerts</groupId>
     <artifactId>mollie</artifactId>
-    <version>4.6.0</version>
+    <version>4.6.1</version>
 
     <name>Mollie with Java</name>
     <description>Java framework to consume the Mollie API</description>

--- a/src/main/java/be/woutschoovaerts/mollie/data/refund/RefundStatus.java
+++ b/src/main/java/be/woutschoovaerts/mollie/data/refund/RefundStatus.java
@@ -8,6 +8,7 @@ public enum RefundStatus {
 
     QUEUED,
     PENDING,
+    CANCELED,
     PROCESSING,
     REFUNDED,
     FAILED;


### PR DESCRIPTION
Relates to https://github.com/zwaldeck/mollie/issues/127

Adding missing `canceled` refund status support, as is described in the [API docs](https://docs.mollie.com/docs/refunds#refund-statuses).