### PR TITLE
Added missing locale en_GB

### DIFF
--- a/src/main/java/be/woutschoovaerts/mollie/data/common/Locale.java
+++ b/src/main/java/be/woutschoovaerts/mollie/data/common/Locale.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
 
 public enum Locale {
 
+    en_GB,
     en_US,
     nl_NL,
     nl_BE,


### PR DESCRIPTION
Added locale en_GB which was missing from the documented list of locales supported by the Mollie API (cf. https://docs.mollie.com/reference/common-data-types#locale)

Closes zwaldeck/mollie#138

